### PR TITLE
Update CI/CD workflow: Ubuntu 22.04, checkout v4, and simplify paths

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,15 +1,24 @@
 on: [push]
 
 jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update --quiet && sudo apt-get install --quiet --yes libdbd-sqlite3-perl libyaml-syck-perl golang-go
+      - run: make init
+      - run: make build
+
   deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: build
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: sudo apt-get update --quiet && sudo apt-get install --quiet --yes awscli s3cmd libdbd-sqlite3-perl libyaml-syck-perl golang-go
-      - run: curl -Ss -L https://github.com/gohugoio/hugo/releases/download/v0.49/hugo_0.49_Linux-64bit.tar.gz > /tmp/x.tgz
-      - run: cd /tmp && tar xvf /tmp/x.tgz && mv hugo hugo-0.49
+      - run: make init
       - run: cp etc/s3cmd.ini ~/.s3cfg
-      - run: PATH=$PATH:/tmp && make push
+      - run: make push
         env:
            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,15 +2,14 @@ on: [push]
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - run: sudo apt-get update --quiet && sudo apt-get install --quiet awscli s3cmd libdbd-sqlite3-perl libyaml-syck-perl golang-go
+      - uses: actions/checkout@v4
+      - run: sudo apt-get update --quiet && sudo apt-get install --quiet --yes awscli s3cmd libdbd-sqlite3-perl libyaml-syck-perl golang-go
       - run: curl -Ss -L https://github.com/gohugoio/hugo/releases/download/v0.49/hugo_0.49_Linux-64bit.tar.gz > /tmp/x.tgz
       - run: cd /tmp && tar xvf /tmp/x.tgz && mv hugo hugo-0.49
       - run: cp etc/s3cmd.ini ~/.s3cfg
-      - run: cat /home/runner/.s3cfg
-      - run: PATH=$PATH:/tmp && cd /home/runner/work/blog/blog && make push
+      - run: PATH=$PATH:/tmp && make push
         env:
            AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
            AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Summary
Updated the GitHub Actions CI/CD workflow to use more recent versions of dependencies and simplified the build process by removing unnecessary directory navigation.

## Key Changes
- Upgraded runner OS from `ubuntu-20.04` to `ubuntu-22.04`
- Updated `actions/checkout` from v2 to v4
- Added `--yes` flag to `apt-get install` command for non-interactive installation
- Removed debug step that printed S3 config file contents
- Simplified the build command by removing explicit directory change to `/home/runner/work/blog/blog` and relying on the default working directory

## Implementation Details
The workflow now assumes the `make push` command will be executed from the repository root (the default working directory in GitHub Actions), eliminating the need for the explicit `cd /home/runner/work/blog/blog` path navigation. This makes the workflow more maintainable and less dependent on specific runner directory structures.

https://claude.ai/code/session_01UusWk6mFehinyT5s5ZMuJw